### PR TITLE
Set legacy Postgres admin group import ID

### DIFF
--- a/imports.tf
+++ b/imports.tf
@@ -14,6 +14,16 @@
 locals {
   legacy_postgresql_imports_enabled = contains(keys(local.legacy_postgresql_server_ids_by_env), var.env)
 
+  legacy_postgresql_platform_admin_group_object_ids_by_env = {
+    demo     = "3c52c98b-07a3-4a97-92b9-298e86bb1ca9"
+    ithc     = "3c52c98b-07a3-4a97-92b9-298e86bb1ca9"
+    perftest = "3c52c98b-07a3-4a97-92b9-298e86bb1ca9"
+    test     = "3c52c98b-07a3-4a97-92b9-298e86bb1ca9"
+    stg      = "3c52c98b-07a3-4a97-92b9-298e86bb1ca9"
+  }
+
+  legacy_postgresql_platform_admin_group_object_id = var.legacy_postgresql_platform_admin_group_object_id != "" ? var.legacy_postgresql_platform_admin_group_object_id : try(local.legacy_postgresql_platform_admin_group_object_ids_by_env[var.env], "")
+
   legacy_postgresql_imports = {
     for key, server in local.legacy_postgresql_servers : key => {
       component           = server.component
@@ -110,10 +120,10 @@ data "azurerm_key_vault_secret" "legacy_POSTGRES_DATABASE" {
 }
 
 import {
-  for_each = var.legacy_postgresql_platform_admin_group_object_id == "" ? {} : local.legacy_postgresql_imports
+  for_each = local.legacy_postgresql_platform_admin_group_object_id == "" ? {} : local.legacy_postgresql_imports
 
   to = module.legacy_postgresql[each.key].azurerm_postgresql_flexible_server_active_directory_administrator.pgsql_adadmin
-  id = "${each.value.server_id}/administrators/${var.legacy_postgresql_platform_admin_group_object_id}"
+  id = "${each.value.server_id}/administrators/${local.legacy_postgresql_platform_admin_group_object_id}"
 }
 
 import {

--- a/variables.tf
+++ b/variables.tf
@@ -63,7 +63,7 @@ variable "service_bus_sku" {
 }
 
 variable "legacy_postgresql_platform_admin_group_object_id" {
-  description = "Object ID for the DTS Platform Operations PostgreSQL Admin Access group used by the PostgreSQL module. Required for importing existing legacy PostgreSQL Azure AD admin resources."
+  description = "Optional override for the DTS Platform Operations PostgreSQL Admin Access group object ID used when importing existing legacy PostgreSQL Azure AD admin resources."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
## Summary
- set `legacy_postgresql_platform_admin_group_object_id` to the existing DTS Platform Operations PostgreSQL Admin Access object ID
- ensures legacy PostgreSQL `pgsql_adadmin` resources are imported instead of recreated after PR #61 merge

## Verification
- confirmed failed STG apply attempted to create existing `pgsql_adadmin` resources with object ID `3c52c98b-07a3-4a97-92b9-298e86bb1ca9`
- `git diff --check` passed
- `terraform fmt` / `terraform validate` not run locally: Terraform binary is not installed in this workspace