### PR TITLE
Fix nonprod sync failures

### DIFF
--- a/consolidated-databases.tf
+++ b/consolidated-databases.tf
@@ -35,7 +35,7 @@ module "opal_consolidated_postgresql" {
 resource "azurerm_key_vault_secret" "CONSOLIDATED_POSTGRES_USER" {
   count = local.consolidated_postgresql_enabled ? 1 : 0
 
-  name         = "${var.component}-CONSOLIDATED-POSTGRES-USER"
+  name         = "${var.product}-CONSOLIDATED-POSTGRES-USER"
   value        = module.opal_consolidated_postgresql[0].username
   key_vault_id = module.opal_key_vault.key_vault_id
 }
@@ -43,7 +43,7 @@ resource "azurerm_key_vault_secret" "CONSOLIDATED_POSTGRES_USER" {
 resource "azurerm_key_vault_secret" "CONSOLIDATED_POSTGRES_PASS" {
   count = local.consolidated_postgresql_enabled ? 1 : 0
 
-  name         = "${var.component}-CONSOLIDATED-POSTGRES-PASS"
+  name         = "${var.product}-CONSOLIDATED-POSTGRES-PASS"
   value        = module.opal_consolidated_postgresql[0].password
   key_vault_id = module.opal_key_vault.key_vault_id
 }
@@ -51,7 +51,7 @@ resource "azurerm_key_vault_secret" "CONSOLIDATED_POSTGRES_PASS" {
 resource "azurerm_key_vault_secret" "CONSOLIDATED_POSTGRES_HOST" {
   count = local.consolidated_postgresql_enabled ? 1 : 0
 
-  name         = "${var.component}-CONSOLIDATED-POSTGRES-HOST"
+  name         = "${var.product}-CONSOLIDATED-POSTGRES-HOST"
   value        = module.opal_consolidated_postgresql[0].fqdn
   key_vault_id = module.opal_key_vault.key_vault_id
 }
@@ -59,7 +59,7 @@ resource "azurerm_key_vault_secret" "CONSOLIDATED_POSTGRES_HOST" {
 resource "azurerm_key_vault_secret" "CONSOLIDATED_POSTGRES_PORT" {
   count = local.consolidated_postgresql_enabled ? 1 : 0
 
-  name         = "${var.component}-CONSOLIDATED-POSTGRES-PORT"
+  name         = "${var.product}-CONSOLIDATED-POSTGRES-PORT"
   value        = local.db_port
   key_vault_id = module.opal_key_vault.key_vault_id
 }
@@ -67,7 +67,7 @@ resource "azurerm_key_vault_secret" "CONSOLIDATED_POSTGRES_PORT" {
 resource "azurerm_key_vault_secret" "CONSOLIDATED_POSTGRES_DATABASES" {
   for_each = local.consolidated_postgresql_enabled ? local.consolidated_postgresql_databases : {}
 
-  name         = "${var.component}-CONSOLIDATED-POSTGRES-${each.key}-DATABASE"
+  name         = "${var.product}-CONSOLIDATED-POSTGRES-${replace(each.key, "_", "-")}-DATABASE"
   value        = each.value
   key_vault_id = module.opal_key_vault.key_vault_id
 }

--- a/virtual-machine.tf
+++ b/virtual-machine.tf
@@ -68,6 +68,7 @@ module "virtual-machine" {
 
   nessus_install             = false
   install_splunk_uf          = false
+  remove_splunk_uf           = false
   install_dynatrace_oneagent = false
   install_azure_monitor      = false
 


### PR DESCRIPTION
## What

Fix the non-prod sync failures seen after master was synced to demo, ithc and perftest/test.

- Use `var.product` for consolidated Postgres Key Vault secret names instead of `var.component` because Jenkins passes `component` as null/empty for this shared-infrastructure repo.
- Replace underscores in consolidated database secret name keys with dashes so `LOG_AUDIT` and `FILE_HANDLER` produce valid Key Vault secret names.
- Disable the default Splunk UF removal bootstrap on the perftest/test Windows VMs. Splunk install is already disabled, but the VM module defaults `remove_splunk_uf` to true, which was still creating the `HMCTSVMBootstrap` CustomScriptExtension that failed in perftest.

## Why

Demo and ITHC failed during Terraform plan because Azure Key Vault secret names may only contain alphanumeric characters and dashes.

Perftest/test got past the Postgres changes but failed applying the VM bootstrap extension for `opal-perf-test-vm-0`. The VM configuration explicitly disables Splunk, Nessus, Dynatrace and Azure Monitor installation, so the Splunk removal bootstrap should also be disabled.

## Validation

- `git diff --check`
- Inspected consolidated secret names now render from `var.product` and sanitize `_` to `-`
- Confirmed `remove_splunk_uf` is a supported input on `terraform-module-virtual-machine`