### PR TITLE
Upgrade Postgres databases to version 17

### DIFF
--- a/consolidated-databases.tf
+++ b/consolidated-databases.tf
@@ -19,7 +19,7 @@ module "opal_consolidated_postgresql" {
   component            = var.component
   business_area        = "sds"
   common_tags          = var.common_tags
-  collation            = "en_US.utf8"
+  collation            = "en_GB.utf8"
   admin_user_object_id = var.jenkins_AAD_objectId
 
   pgsql_databases = [
@@ -29,7 +29,7 @@ module "opal_consolidated_postgresql" {
   ]
 
   pgsql_server_configuration = local.consolidated_postgresql_server_configuration
-  pgsql_version              = "16"
+  pgsql_version              = "17"
 }
 
 resource "azurerm_key_vault_secret" "CONSOLIDATED_POSTGRES_USER" {

--- a/consolidated-databases.tf
+++ b/consolidated-databases.tf
@@ -19,7 +19,7 @@ module "opal_consolidated_postgresql" {
   component            = var.component
   business_area        = "sds"
   common_tags          = var.common_tags
-  collation            = "en_GB.utf8"
+  collation            = local.db_collation
   admin_user_object_id = var.jenkins_AAD_objectId
 
   pgsql_databases = [
@@ -29,7 +29,7 @@ module "opal_consolidated_postgresql" {
   ]
 
   pgsql_server_configuration = local.consolidated_postgresql_server_configuration
-  pgsql_version              = "17"
+  pgsql_version              = local.db_version
 }
 
 resource "azurerm_key_vault_secret" "CONSOLIDATED_POSTGRES_USER" {

--- a/database.tf
+++ b/database.tf
@@ -79,7 +79,7 @@ module "opal_postgresql" {
   component            = var.component
   business_area        = "sds"
   common_tags          = var.common_tags
-  collation            = "en_US.utf8"
+  collation            = "en_GB.utf8"
   admin_user_object_id = var.jenkins_AAD_objectId
   pgsql_databases = [
     {
@@ -120,6 +120,6 @@ module "opal_postgresql" {
     }
   ]
 
-  pgsql_version = "16"
+  pgsql_version = "17"
 }
 

--- a/database.tf
+++ b/database.tf
@@ -79,8 +79,8 @@ module "opal_postgresql" {
   component            = var.component
   business_area        = "sds"
   common_tags          = var.common_tags
-  collation     = local.db_collation
-  pgsql_version = local.db_version
+  collation            = local.db_collation
+  pgsql_version        = local.db_version
   admin_user_object_id = var.jenkins_AAD_objectId
   pgsql_databases = [
     {

--- a/database.tf
+++ b/database.tf
@@ -79,7 +79,8 @@ module "opal_postgresql" {
   component            = var.component
   business_area        = "sds"
   common_tags          = var.common_tags
-  collation            = "en_GB.utf8"
+  collation     = local.db_collation
+  pgsql_version = local.db_version
   admin_user_object_id = var.jenkins_AAD_objectId
   pgsql_databases = [
     {
@@ -119,7 +120,5 @@ module "opal_postgresql" {
       value = "7"
     }
   ]
-
-  pgsql_version = "17"
 }
 

--- a/locals.tf
+++ b/locals.tf
@@ -30,8 +30,8 @@ locals {
       component     = "fines-service"
       db_name       = "opal-fines-db"
       enabled_envs  = ["demo", "ithc", "perftest", "test", "stg"]
-      collation     = null
-      pgsql_version = "15"
+      collation     = "en_GB.utf8"
+      pgsql_version = "17"
       pgsql_databases = concat(
         [
           {
@@ -60,8 +60,8 @@ locals {
       component                  = "user-service"
       db_name                    = "opal-user-db"
       enabled_envs               = ["demo", "ithc", "perftest", "test", "stg"]
-      collation                  = "en_US.utf8"
-      pgsql_version              = "16"
+      collation                  = "en_GB.utf8"
+      pgsql_version              = "17"
       pgsql_databases            = [{ name = "opal-user-db" }]
       pgsql_server_configuration = local.legacy_postgresql_default_server_configuration
     }
@@ -70,8 +70,8 @@ locals {
       component                  = "logging-service"
       db_name                    = "opal-logging-db"
       enabled_envs               = ["stg"]
-      collation                  = null
-      pgsql_version              = "15"
+      collation                  = "en_GB.utf8"
+      pgsql_version              = "17"
       pgsql_databases            = [{ name = "opal-logging-db" }]
       pgsql_server_configuration = local.legacy_postgresql_fdw_server_configuration
     }
@@ -80,8 +80,8 @@ locals {
       component                  = "log-audit-service"
       db_name                    = "opal-log-audit-db"
       enabled_envs               = ["stg"]
-      collation                  = null
-      pgsql_version              = "15"
+      collation                  = "en_GB.utf8"
+      pgsql_version              = "17"
       pgsql_databases            = [{ name = "opal-log-audit-db" }]
       pgsql_server_configuration = local.legacy_postgresql_default_server_configuration
     }
@@ -90,8 +90,8 @@ locals {
       component                  = "file-handler"
       db_name                    = "opal-file-db"
       enabled_envs               = ["demo", "perftest", "test", "stg"]
-      collation                  = "en_US.utf8"
-      pgsql_version              = "16"
+      collation                  = "en_GB.utf8"
+      pgsql_version              = "17"
       pgsql_databases            = [{ name = "opal-file-db" }]
       pgsql_server_configuration = local.legacy_postgresql_default_server_configuration
     }
@@ -100,8 +100,8 @@ locals {
       component                  = "maintenance-service"
       db_name                    = "opal-maintenance-db"
       enabled_envs               = ["demo", "stg"]
-      collation                  = "en_US.utf8"
-      pgsql_version              = "16"
+      collation                  = "en_GB.utf8"
+      pgsql_version              = "17"
       pgsql_databases            = [{ name = "opal-maintenance-db" }]
       pgsql_server_configuration = local.legacy_postgresql_default_server_configuration
     }
@@ -110,8 +110,8 @@ locals {
       component                  = "print-service"
       db_name                    = "opal-print-db"
       enabled_envs               = ["stg"]
-      collation                  = null
-      pgsql_version              = "15"
+      collation                  = "en_GB.utf8"
+      pgsql_version              = "17"
       pgsql_databases            = [{ name = "opal-print-db" }]
       pgsql_server_configuration = local.legacy_postgresql_default_server_configuration
     }

--- a/locals.tf
+++ b/locals.tf
@@ -62,8 +62,8 @@ locals {
       component                  = "user-service"
       db_name                    = "opal-user-db"
       enabled_envs               = ["demo", "ithc", "perftest", "test", "stg"]
-      collation     = local.db_collation
-      pgsql_version = local.db_version
+      collation                  = local.db_collation
+      pgsql_version              = local.db_version
       pgsql_databases            = [{ name = "opal-user-db" }]
       pgsql_server_configuration = local.legacy_postgresql_default_server_configuration
     }
@@ -72,8 +72,8 @@ locals {
       component                  = "logging-service"
       db_name                    = "opal-logging-db"
       enabled_envs               = ["stg"]
-      collation     = local.db_collation
-      pgsql_version = local.db_version
+      collation                  = local.db_collation
+      pgsql_version              = local.db_version
       pgsql_databases            = [{ name = "opal-logging-db" }]
       pgsql_server_configuration = local.legacy_postgresql_fdw_server_configuration
     }
@@ -82,8 +82,8 @@ locals {
       component                  = "log-audit-service"
       db_name                    = "opal-log-audit-db"
       enabled_envs               = ["stg"]
-      collation     = local.db_collation
-      pgsql_version = local.db_version
+      collation                  = local.db_collation
+      pgsql_version              = local.db_version
       pgsql_databases            = [{ name = "opal-log-audit-db" }]
       pgsql_server_configuration = local.legacy_postgresql_default_server_configuration
     }
@@ -92,8 +92,8 @@ locals {
       component                  = "file-handler"
       db_name                    = "opal-file-db"
       enabled_envs               = ["demo", "perftest", "test", "stg"]
-      collation     = local.db_collation
-      pgsql_version = local.db_version
+      collation                  = local.db_collation
+      pgsql_version              = local.db_version
       pgsql_databases            = [{ name = "opal-file-db" }]
       pgsql_server_configuration = local.legacy_postgresql_default_server_configuration
     }
@@ -102,8 +102,8 @@ locals {
       component                  = "maintenance-service"
       db_name                    = "opal-maintenance-db"
       enabled_envs               = ["demo", "stg"]
-      collation     = local.db_collation
-      pgsql_version = local.db_version
+      collation                  = local.db_collation
+      pgsql_version              = local.db_version
       pgsql_databases            = [{ name = "opal-maintenance-db" }]
       pgsql_server_configuration = local.legacy_postgresql_default_server_configuration
     }
@@ -112,8 +112,8 @@ locals {
       component                  = "print-service"
       db_name                    = "opal-print-db"
       enabled_envs               = ["stg"]
-      collation     = local.db_collation
-      pgsql_version = local.db_version
+      collation                  = local.db_collation
+      pgsql_version              = local.db_version
       pgsql_databases            = [{ name = "opal-print-db" }]
       pgsql_server_configuration = local.legacy_postgresql_default_server_configuration
     }

--- a/locals.tf
+++ b/locals.tf
@@ -6,6 +6,8 @@ locals {
   db_log_audit_name    = "${var.product}-log-audit-db"
   db_file_handler_name = "${var.product}-file-db"
   db_port              = 5432
+  db_version           = "17"
+  db_collation         = "en_GB.utf8"
 
   legacy_postgresql_default_server_configuration = [
     {
@@ -30,8 +32,8 @@ locals {
       component     = "fines-service"
       db_name       = "opal-fines-db"
       enabled_envs  = ["demo", "ithc", "perftest", "test", "stg"]
-      collation     = "en_GB.utf8"
-      pgsql_version = "17"
+      collation     = local.db_collation
+      pgsql_version = local.db_version
       pgsql_databases = concat(
         [
           {
@@ -60,8 +62,8 @@ locals {
       component                  = "user-service"
       db_name                    = "opal-user-db"
       enabled_envs               = ["demo", "ithc", "perftest", "test", "stg"]
-      collation                  = "en_GB.utf8"
-      pgsql_version              = "17"
+      collation     = local.db_collation
+      pgsql_version = local.db_version
       pgsql_databases            = [{ name = "opal-user-db" }]
       pgsql_server_configuration = local.legacy_postgresql_default_server_configuration
     }
@@ -70,8 +72,8 @@ locals {
       component                  = "logging-service"
       db_name                    = "opal-logging-db"
       enabled_envs               = ["stg"]
-      collation                  = "en_GB.utf8"
-      pgsql_version              = "17"
+      collation     = local.db_collation
+      pgsql_version = local.db_version
       pgsql_databases            = [{ name = "opal-logging-db" }]
       pgsql_server_configuration = local.legacy_postgresql_fdw_server_configuration
     }
@@ -80,8 +82,8 @@ locals {
       component                  = "log-audit-service"
       db_name                    = "opal-log-audit-db"
       enabled_envs               = ["stg"]
-      collation                  = "en_GB.utf8"
-      pgsql_version              = "17"
+      collation     = local.db_collation
+      pgsql_version = local.db_version
       pgsql_databases            = [{ name = "opal-log-audit-db" }]
       pgsql_server_configuration = local.legacy_postgresql_default_server_configuration
     }
@@ -90,8 +92,8 @@ locals {
       component                  = "file-handler"
       db_name                    = "opal-file-db"
       enabled_envs               = ["demo", "perftest", "test", "stg"]
-      collation                  = "en_GB.utf8"
-      pgsql_version              = "17"
+      collation     = local.db_collation
+      pgsql_version = local.db_version
       pgsql_databases            = [{ name = "opal-file-db" }]
       pgsql_server_configuration = local.legacy_postgresql_default_server_configuration
     }
@@ -100,8 +102,8 @@ locals {
       component                  = "maintenance-service"
       db_name                    = "opal-maintenance-db"
       enabled_envs               = ["demo", "stg"]
-      collation                  = "en_GB.utf8"
-      pgsql_version              = "17"
+      collation     = local.db_collation
+      pgsql_version = local.db_version
       pgsql_databases            = [{ name = "opal-maintenance-db" }]
       pgsql_server_configuration = local.legacy_postgresql_default_server_configuration
     }
@@ -110,8 +112,8 @@ locals {
       component                  = "print-service"
       db_name                    = "opal-print-db"
       enabled_envs               = ["stg"]
-      collation                  = "en_GB.utf8"
-      pgsql_version              = "17"
+      collation     = local.db_collation
+      pgsql_version = local.db_version
       pgsql_databases            = [{ name = "opal-print-db" }]
       pgsql_server_configuration = local.legacy_postgresql_default_server_configuration
     }


### PR DESCRIPTION
## What

Upgrade Opal PostgreSQL flexible server definitions to PostgreSQL 17 and standardise database collation on `en_GB.utf8`.

This updates:

- the shared `opal_postgresql` module
- the consolidated non-prod PostgreSQL module
- all legacy PostgreSQL server adoption entries

## Why

Align all Opal PostgreSQL definitions on the same PostgreSQL major version and locale/collation.

## Validation

- `git diff --check`
- Checked there are no remaining configured `pgsql_version` values of `15` or `16`
- Checked configured database collations are set to `en_GB.utf8`