### PR TITLE
Fix consolidated DB secret cutover

### DIFF
--- a/legacy-databases.tf
+++ b/legacy-databases.tf
@@ -31,7 +31,7 @@ resource "azurerm_key_vault_secret" "legacy_POSTGRES_USER" {
   for_each = local.legacy_postgresql_servers
 
   name         = "${each.value.component}-POSTGRES-USER"
-  value        = module.legacy_postgresql[each.key].username
+  value        = contains(local.consolidated_postgresql_legacy_secret_cutover_keys, each.key) ? module.opal_consolidated_postgresql[0].username : module.legacy_postgresql[each.key].username
   key_vault_id = module.opal_key_vault.key_vault_id
 }
 
@@ -39,7 +39,7 @@ resource "azurerm_key_vault_secret" "legacy_POSTGRES_PASS" {
   for_each = local.legacy_postgresql_servers
 
   name         = "${each.value.component}-POSTGRES-PASS"
-  value        = module.legacy_postgresql[each.key].password
+  value        = contains(local.consolidated_postgresql_legacy_secret_cutover_keys, each.key) ? module.opal_consolidated_postgresql[0].password : module.legacy_postgresql[each.key].password
   key_vault_id = module.opal_key_vault.key_vault_id
 }
 
@@ -47,7 +47,7 @@ resource "azurerm_key_vault_secret" "legacy_POSTGRES_HOST" {
   for_each = local.legacy_postgresql_servers
 
   name         = "${each.value.component}-POSTGRES-HOST"
-  value        = module.legacy_postgresql[each.key].fqdn
+  value        = contains(local.consolidated_postgresql_legacy_secret_cutover_keys, each.key) ? module.opal_consolidated_postgresql[0].fqdn : module.legacy_postgresql[each.key].fqdn
   key_vault_id = module.opal_key_vault.key_vault_id
 }
 

--- a/locals.tf
+++ b/locals.tf
@@ -168,11 +168,14 @@ locals {
     PRINT        = "opal-print-db"
   }
 
-  service_keyvault_databases_prefix = {
-    FINES   = "fines-service"
-    USER    = "user-service"
+  consolidated_postgresql_legacy_secret_cutover_keys = local.consolidated_postgresql_enabled ? toset([
+    "fines-service",
+    "user-service",
+  ]) : toset([])
+
+  service_keyvault_databases_prefix = local.consolidated_postgresql_enabled ? {
     LOGGING = "logging-service"
-  }
+  } : {}
 
   consolidated_postgresql_server_configuration = [
     {


### PR DESCRIPTION
## Summary

Fix the demo/ithc consolidated database secret cutover so existing service Key Vault secrets are updated in-place rather than recreated under a second Terraform resource address.

PR #74 added compatibility secrets for service-style names, but in demo the fines/user secrets are already managed by `legacy_POSTGRES_*`. Terraform therefore attempted to create duplicate `fines-service-POSTGRES-*` and `user-service-POSTGRES-*` secrets and failed because those secret versions already exist.

This change:
- updates the existing fines/user `legacy_POSTGRES_USER`, `legacy_POSTGRES_PASS`, and `legacy_POSTGRES_HOST` resources to use the consolidated PostgreSQL values during consolidated cutover
- keeps the separate compatibility-secret path for logging, which is not currently adopted as a legacy PostgreSQL server in demo/ithc
- avoids duplicate Terraform ownership of the same Key Vault secret names

## Validation

- `terraform init -backend=false -input=false`
- `terraform fmt -check -diff`
- `git diff --check`
- `terraform validate`
