### PR TITLE
Update test shared Postgres version

### DIFF
--- a/database.tf
+++ b/database.tf
@@ -79,8 +79,9 @@ module "opal_postgresql" {
   component            = var.component
   business_area        = "sds"
   common_tags          = var.common_tags
-  collation            = "en_US.utf8"
+  collation            = var.env == "test" ? "en_GB.utf8" : "en_US.utf8"
   admin_user_object_id = var.jenkins_AAD_objectId
+  pgsql_version        = var.env == "test" ? "17" : "16"
   pgsql_databases = [
     {
       name : local.db_fines_name
@@ -120,6 +121,4 @@ module "opal_postgresql" {
     }
   ]
 
-  pgsql_version = "16"
 }
-


### PR DESCRIPTION
## Summary

Update the existing shared `opal_postgresql` server in `test` to PostgreSQL 17 with `en_GB.utf8` collation.

Non-test environments remain on the existing PostgreSQL 16 / `en_US.utf8` settings.

## Validation

- `terraform init -backend=false -input=false`
- `terraform fmt -check -diff`
- `git diff --check`
- `terraform validate`
