### PR TITLE
Fix maintenance service Postgres adoption

### DIFF
--- a/legacy-databases.tf
+++ b/legacy-databases.tf
@@ -6,7 +6,7 @@
 # Key Vault secret names remain unchanged.
 
 module "legacy_postgresql" {
-  for_each = local.legacy_postgresql_all_servers
+  for_each = local.postgresql_all_enabed_servers
 
   providers = {
     azurerm.postgres_network = azurerm

--- a/locals.tf
+++ b/locals.tf
@@ -93,13 +93,18 @@ locals {
     }
 
     "maintenance-service" = {
-      component                  = "maintenance-service"
-      db_name                    = "opal-maintenance-db"
-      enabled_envs               = ["demo", "stg"]
-      collation                  = local.db_collation
-      pgsql_version              = local.db_version
-      pgsql_databases            = [{ name = "opal-maintenance-db" }]
-      pgsql_server_configuration = local.legacy_postgresql_default_server_configuration
+      component       = "maintenance-service"
+      db_name         = "opal-maintenance-db"
+      enabled_envs    = ["demo", "stg"]
+      collation       = local.db_collation
+      pgsql_version   = local.db_version
+      pgsql_databases = [{ name = "opal-maintenance-db" }]
+      pgsql_server_configuration = [
+        {
+          name  = "backslash_quote"
+          value = "safe_encoding"
+        }
+      ]
     }
 
     "print-service" = {

--- a/maintenance-service-imports.tf
+++ b/maintenance-service-imports.tf
@@ -5,14 +5,16 @@
 # opal-maintenance-service-stg, but Azure already has that flexible server.
 # Keep these only for the adoption run, then remove them once the resources are
 # present in this repo's Terraform state.
+#
+# Do not import the maintenance-service database or platform AAD admin here:
+# the STG adoption plan showed those objects do not exist remotely yet, so they
+# should be created by Terraform after the existing server has been imported.
 
 locals {
   maintenance_service_legacy_imports = var.env == "stg" ? {
     "maintenance-service" = {
-      server_id               = "/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/opal-maintenance-service-data-stg/providers/Microsoft.DBforPostgreSQL/flexibleServers/opal-maintenance-service-stg"
-      database_name           = "opal-maintenance-db"
-      configuration_name      = "backslash_quote"
-      platform_admin_group_id = "3c52c98b-07a3-4a97-92b9-298e86bb1ca9"
+      server_id          = "/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/opal-maintenance-service-data-stg/providers/Microsoft.DBforPostgreSQL/flexibleServers/opal-maintenance-service-stg"
+      configuration_name = "backslash_quote"
     }
   } : {}
 }
@@ -27,22 +29,8 @@ import {
 import {
   for_each = local.maintenance_service_legacy_imports
 
-  to = module.legacy_postgresql[each.key].azurerm_postgresql_flexible_server_database.pg_databases[each.value.database_name]
-  id = "${each.value.server_id}/databases/${each.value.database_name}"
-}
-
-import {
-  for_each = local.maintenance_service_legacy_imports
-
   to = module.legacy_postgresql[each.key].azurerm_postgresql_flexible_server_configuration.pgsql_server_config[each.value.configuration_name]
   id = "${each.value.server_id}/configurations/${each.value.configuration_name}"
-}
-
-import {
-  for_each = local.maintenance_service_legacy_imports
-
-  to = module.legacy_postgresql[each.key].azurerm_postgresql_flexible_server_active_directory_administrator.pgsql_adadmin
-  id = "${each.value.server_id}/administrators/${each.value.platform_admin_group_id}"
 }
 
 import {

--- a/maintenance-service-imports.tf
+++ b/maintenance-service-imports.tf
@@ -6,8 +6,8 @@
 # Keep these only for the adoption run, then remove them once the resources are
 # present in this repo's Terraform state.
 #
-# Do not import the maintenance-service database or platform AAD admin here:
-# the STG adoption plan showed those objects do not exist remotely yet, so they
+# Do not import the maintenance-service database or AAD admins here:
+# the STG adoption plans showed those objects do not exist remotely yet, so they
 # should be created by Terraform after the existing server has been imported.
 
 locals {
@@ -31,11 +31,4 @@ import {
 
   to = module.legacy_postgresql[each.key].azurerm_postgresql_flexible_server_configuration.pgsql_server_config[each.value.configuration_name]
   id = "${each.value.server_id}/configurations/${each.value.configuration_name}"
-}
-
-import {
-  for_each = local.maintenance_service_legacy_imports
-
-  to = module.legacy_postgresql[each.key].azurerm_postgresql_flexible_server_active_directory_administrator.pgsql_principal_admin[0]
-  id = "${each.value.server_id}/administrators/${var.jenkins_AAD_objectId}"
 }

--- a/maintenance-service-imports.tf
+++ b/maintenance-service-imports.tf
@@ -1,0 +1,53 @@
+# Temporary import blocks for adopting the existing STG maintenance-service
+# PostgreSQL resources into opal-shared-infrastructure state.
+#
+# Jenkins #83 failed because Terraform planned to create
+# opal-maintenance-service-stg, but Azure already has that flexible server.
+# Keep these only for the adoption run, then remove them once the resources are
+# present in this repo's Terraform state.
+
+locals {
+  maintenance_service_legacy_imports = var.env == "stg" ? {
+    "maintenance-service" = {
+      server_id               = "/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/opal-maintenance-service-data-stg/providers/Microsoft.DBforPostgreSQL/flexibleServers/opal-maintenance-service-stg"
+      database_name           = "opal-maintenance-db"
+      configuration_name      = "backslash_quote"
+      platform_admin_group_id = "3c52c98b-07a3-4a97-92b9-298e86bb1ca9"
+    }
+  } : {}
+}
+
+import {
+  for_each = local.maintenance_service_legacy_imports
+
+  to = module.legacy_postgresql[each.key].azurerm_postgresql_flexible_server.pgsql_server
+  id = each.value.server_id
+}
+
+import {
+  for_each = local.maintenance_service_legacy_imports
+
+  to = module.legacy_postgresql[each.key].azurerm_postgresql_flexible_server_database.pg_databases[each.value.database_name]
+  id = "${each.value.server_id}/databases/${each.value.database_name}"
+}
+
+import {
+  for_each = local.maintenance_service_legacy_imports
+
+  to = module.legacy_postgresql[each.key].azurerm_postgresql_flexible_server_configuration.pgsql_server_config[each.value.configuration_name]
+  id = "${each.value.server_id}/configurations/${each.value.configuration_name}"
+}
+
+import {
+  for_each = local.maintenance_service_legacy_imports
+
+  to = module.legacy_postgresql[each.key].azurerm_postgresql_flexible_server_active_directory_administrator.pgsql_adadmin
+  id = "${each.value.server_id}/administrators/${each.value.platform_admin_group_id}"
+}
+
+import {
+  for_each = local.maintenance_service_legacy_imports
+
+  to = module.legacy_postgresql[each.key].azurerm_postgresql_flexible_server_active_directory_administrator.pgsql_principal_admin[0]
+  id = "${each.value.server_id}/administrators/${var.jenkins_AAD_objectId}"
+}


### PR DESCRIPTION
## What

- Restricts the `legacy_postgresql` module back to environment-enabled legacy servers.
- Adds temporary STG import blocks for the existing `maintenance-service` PostgreSQL flexible server, database, server config, and AAD administrators.

## Why

Jenkins #83 planned to create `opal-maintenance-service-stg`, but Azure already has that flexible server, so the STG resources need importing into this repo state rather than creating.

## Validation

- `terraform fmt -check`
- `terraform validate -no-color`
- `git diff --check`

Note: validated locally with Terraform 1.15.3; repo currently pins 1.15.4. The only validation warnings were existing AzureRM `skip_provider_registration` deprecations.

## Follow-up

Remove `maintenance-service-imports.tf` after the adoption apply has imported these STG resources into Terraform state.