### PR TITLE
Avoid null managed Redis outputs

### DIFF
--- a/redis_managed.tf
+++ b/redis_managed.tf
@@ -22,34 +22,8 @@ module "opal_managed_redis" {
   create_private_endpoint            = true
   subnet_id                          = data.azurerm_subnet.redis_private_endpoint.id
   private_dns_zone_ids               = ["/subscriptions/${var.private_dns_subscription_id}/resourceGroups/core-infra-intsvc-rg/providers/Microsoft.Network/privateDnsZones/privatelink.redis.azure.net"]
-  access_keys_authentication_enabled = true
+  access_keys_authentication_enabled = false
 
   # Backup (persistence) options:
   persistence_rdb_backup_frequency = "6h"
 }
-
-
-resource "azurerm_key_vault_secret" "managed_redis_primary_access_key" {
-  name         = "managed-redis-primary-access-key"
-  value        = module.opal_managed_redis.primary_access_key
-  key_vault_id = module.opal_key_vault.key_vault_id
-}
-resource "azurerm_key_vault_secret" "managed_redis_hostname" {
-  name         = "managed-redis-hostname"
-  value        = module.opal_managed_redis.hostname
-  key_vault_id = module.opal_key_vault.key_vault_id
-}
-resource "azurerm_key_vault_secret" "managed_redis_port" {
-  name         = "managed-redis-port"
-  value        = module.opal_managed_redis.port
-  key_vault_id = module.opal_key_vault.key_vault_id
-}
-
-resource "azurerm_key_vault_secret" "managed_redis_connection_string" {
-  name  = "managed-redis-connection-string"
-  value = "rediss://:${urlencode(module.opal_managed_redis.primary_access_key)}@${module.opal_managed_redis.hostname}:${module.opal_managed_redis.port}?tls=true"
-
-  key_vault_id = module.opal_key_vault.key_vault_id
-}
-
-


### PR DESCRIPTION
## Summary
- disable access key authentication for the managed Redis rollout
- remove managed Redis Key Vault secrets that consume null module outputs during plan

## Why
The managed Redis module currently returns null for database port/access key outputs while the default database is being added, causing azurerm_key_vault_secret values and connection string interpolation to fail during the pipeline plan.

## Testing
- git diff --check
- searched for remaining managed Redis access key/port output references

Terraform was not run locally because the binary is not installed in this environment.